### PR TITLE
fix async callback

### DIFF
--- a/main.go
+++ b/main.go
@@ -245,7 +245,7 @@ func freqHz(freqStr string) (freq uint32, err error) {
 	return
 }
 
-func rtlsdrCallback(buf []byte, ctx *rtl.UserCtx) {
+func rtlsdrCallback(buf []byte) {
 	var i int
 
 	if dongle.mute > 0 && dongle.mute < len(buf) {


### PR DESCRIPTION
The async callback has changed due to "Rules for passing pointers between Go and C" https://github.com/golang/proposal/blob/master/design/12416-cgo-pointers.md
